### PR TITLE
fix :MinValidatorForNumber

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MinValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MinValidatorForNumber.java
@@ -32,8 +32,12 @@ public class MinValidatorForNumber implements ConstraintValidator<Min, Number> {
 	@Override
 	public boolean isValid(Number value, ConstraintValidatorContext constraintValidatorContext) {
 		// null values are valid
+		// why is the null value valid when it is incomparable to a long type minValue;
+		// it confuses me because I have to add an extra @Null annotaion above the @Min annotation to ensure
+		// the value violate the min value constraint
+ 
 		if ( value == null ) {
-			return true;
+			return false;
 		}
 
 		//handling of NaN, positive infinity and negative infinity


### PR DESCRIPTION
why is the null value valid when it is incomparable to a long type minValue;
 it confuses me because I have to add an extra @Null annotaion above the @Min annotation to ensure
 the value violate the min value constraint